### PR TITLE
Fixed wrong values being picked for fileSize and md5

### DIFF
--- a/src/main/java/com/therandomlabs/curseapi/file/CurseFile.java
+++ b/src/main/java/com/therandomlabs/curseapi/file/CurseFile.java
@@ -694,7 +694,7 @@ public final class CurseFile implements Comparable<CurseFile> {
 		nameOnDisk = Documents.getValue(document, "class=text-sm=2;text");
 		getMavenDependency();
 
-		fileSize = Documents.getValue(document, "class=text-sm=8;text");
+		fileSize = Documents.getValue(document, "class=text-sm=10;text");
 
 		//TODO replace linkouts
 		final Elements userContent = document.getElementsByClass("user-content");
@@ -702,7 +702,7 @@ public final class CurseFile implements Comparable<CurseFile> {
 
 		getChangelogString();
 
-		md5 = Documents.getValue(document, "class=text-sm=12;text");
+		md5 = Documents.getValue(document, "class=text-sm=14;text");
 
 		uploaderUsername = Documents.getValue(document, "class=text-sm=4;text");
 


### PR DESCRIPTION
This commit fixes the values for the file size and md5 values in the CurseFile class.

I've tested that with different Minecraft and World of Warcraft mods and everything seems to work now.

Using the code in your example would output:
```
[INFO] File size: 1.12.2
[INFO] MD5: 80,906
```

After the commit this is correct to:
```
[INFO] File size: 252.30 KB
[INFO] MD5: 8c7fea8b779256a681ead355baa11be9
```