### PR TITLE
Add method to get project by curseforge url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 	implementation "io.github.resilience4j:resilience4j-circuitbreaker:${resilience4jVersion}"
 	implementation "io.github.resilience4j:resilience4j-retry:${resilience4jVersion}"
 	implementation "io.github.resilience4j:resilience4j-retrofit:${resilience4jVersion}"
+	compileOnly 'com.google.code.findbugs:annotations:3.0.1'
+	compileOnly 'com.google.code.findbugs:jsr305:3.0.1'
 }
 
 jacocoTestCoverageVerification {

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ dependencies {
 
 	api "org.jsoup:jsoup:1.12.2"
 
+	api group: 'com.google.code.gson', name: 'gson', version: '2.8.6' // Used for getting by URL
+
 	implementation "io.github.resilience4j:resilience4j-circuitbreaker:${resilience4jVersion}"
 	implementation "io.github.resilience4j:resilience4j-retry:${resilience4jVersion}"
 	implementation "io.github.resilience4j:resilience4j-retrofit:${resilience4jVersion}"

--- a/src/main/java/com/therandomlabs/curseapi/CurseAPI.java
+++ b/src/main/java/com/therandomlabs/curseapi/CurseAPI.java
@@ -142,10 +142,11 @@ public final class CurseAPI {
 			final URL u = new URL(url);
 			final URLConnection conn = u.openConnection();
 			conn.connect();
-			final InputStreamReader r = new InputStreamReader(conn.getInputStream());
-			final JsonObject json = JsonParser.parseReader(r).getAsJsonObject();
-			r.close();
-			if (json.has("id")) { return project(json.get("id").getAsInt()); } else if (
+			try(InputStreamReader r = new InputStreamReader(conn.getInputStream())) {
+				final JsonObject json = JsonParser.parseReader(r).getAsJsonObject();
+			if (json.has("id")) {
+				return project(json.get("id").getAsInt());
+			} else if (
 					json.has("title") &&
 							json.get("title").getAsString().equals("Project is queued for fetch")) {
 				try {
@@ -153,6 +154,7 @@ public final class CurseAPI {
 				} catch (InterruptedException ignored) {
 				}
 				return projectByURL(url);
+			}
 			}
 		} catch (MalformedURLException e) {
 			throw new CurseException("Invalid Request URL", e);

--- a/src/main/java/com/therandomlabs/curseapi/CurseAPI.java
+++ b/src/main/java/com/therandomlabs/curseapi/CurseAPI.java
@@ -23,6 +23,7 @@
 
 package com.therandomlabs.curseapi;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
@@ -135,14 +136,17 @@ public final class CurseAPI {
 	 */
 	@SuppressFBWarnings("SECSSSRFUC")
 	public static Optional<CurseProject> projectByURL(String url) throws CurseException {
-		url = url.replaceFirst("^(http[s]?://www\\.|http[s]?://|www\\.)",
-				""); //Remove http(s)://(www.)
-		if(url.startsWith("curseforge.com")) {
-			url = url.replace("curseforge.com", "https://api.cfwidget.com"); //Replace Curseforge URL with cfwidget api
-		} else if(url.startsWith("/")) {
-			url = "https://api.cfwidget.com"+url;
+		url = url.replace("www.", "");
+		//Replace Curseforge URL with cfwidget api
+		if(url.startsWith("curseforge.com") || url.startsWith("https://curseforge.com") || url.startsWith("http://curseforge.com")) {
+			url = url.replace("curseforge.com", "api.cfwidget.com");
+		} else {
+			url = "https://api.cfwidget.com/"+url;
 		}
 		try {
+			if(!url.startsWith("https://")) {
+				url = "https://"+url; //Fix bug which might happen for some weird reason
+			}
 			final URL u = new URL(url);
 			final URLConnection conn = u.openConnection();
 			conn.connect();
@@ -158,6 +162,8 @@ public final class CurseAPI {
 				}
 				return projectByURL(url);
 			}
+			}catch (FileNotFoundException fnf){
+				return Optional.empty(); // Not found :/
 			}
 		} catch (MalformedURLException e) {
 			throw new CurseException("Invalid Request URL", e);

--- a/src/main/java/com/therandomlabs/curseapi/CurseAPI.java
+++ b/src/main/java/com/therandomlabs/curseapi/CurseAPI.java
@@ -61,6 +61,7 @@ import com.therandomlabs.curseapi.project.CurseSearchQuery;
 import com.therandomlabs.curseapi.util.CheckedFunction;
 import com.therandomlabs.curseapi.util.JsoupUtils;
 import com.therandomlabs.curseapi.util.OkHttpUtils;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import okhttp3.HttpUrl;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jsoup.nodes.Element;
@@ -132,6 +133,7 @@ public final class CurseAPI {
 	 * {@link Optional} if the project exists, or otherwise an empty {@link Optional}.
 	 * @throws CurseException if an error occurs.
 	 */
+	@SuppressFBWarnings("SECSSSRFUC")
 	public static Optional<CurseProject> projectByURL(String url) throws CurseException {
 		url = url.replaceFirst("^(http[s]?://www\\.|http[s]?://|www\\.)",
 				""); //Remove http(s)://(www.)

--- a/src/main/java/com/therandomlabs/curseapi/CurseAPI.java
+++ b/src/main/java/com/therandomlabs/curseapi/CurseAPI.java
@@ -137,10 +137,11 @@ public final class CurseAPI {
 	public static Optional<CurseProject> projectByURL(String url) throws CurseException {
 		url = url.replaceFirst("^(http[s]?://www\\.|http[s]?://|www\\.)",
 				""); //Remove http(s)://(www.)
-		if(url.startsWith("curseforge.com"))
-		url = url.replace("curseforge.com", "https://api.cfwidget.com"); //Replace Curseforge URL with cfwidget api
-		else if(url.startsWith("/"))
+		if(url.startsWith("curseforge.com")) {
+			url = url.replace("curseforge.com", "https://api.cfwidget.com"); //Replace Curseforge URL with cfwidget api
+		} else if(url.startsWith("/")) {
 			url = "https://api.cfwidget.com"+url;
+		}
 		try {
 			final URL u = new URL(url);
 			final URLConnection conn = u.openConnection();

--- a/src/main/java/com/therandomlabs/curseapi/CurseAPI.java
+++ b/src/main/java/com/therandomlabs/curseapi/CurseAPI.java
@@ -28,6 +28,7 @@ import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -142,13 +143,12 @@ public final class CurseAPI {
 			final URL u = new URL(url);
 			final URLConnection conn = u.openConnection();
 			conn.connect();
-			try(InputStreamReader r = new InputStreamReader(conn.getInputStream())) {
+			try(InputStreamReader r = new InputStreamReader(conn.getInputStream(),StandardCharsets.UTF_8)) {
 				final JsonObject json = JsonParser.parseReader(r).getAsJsonObject();
 			if (json.has("id")) {
 				return project(json.get("id").getAsInt());
 			} else if (
-					json.has("title") &&
-							json.get("title").getAsString().equals("Project is queued for fetch")) {
+					json.has("title") && "Project is queued for fetch".equals(json.get("title").getAsString())) {
 				try {
 					Thread.sleep(10000);
 				} catch (InterruptedException ignored) {

--- a/src/main/java/com/therandomlabs/curseapi/CurseAPI.java
+++ b/src/main/java/com/therandomlabs/curseapi/CurseAPI.java
@@ -138,10 +138,10 @@ public final class CurseAPI {
 	public static Optional<CurseProject> projectByURL(String url) throws CurseException {
 		url = url.replace("www.", "");
 		//Replace Curseforge URL with cfwidget api
-		if(url.startsWith("curseforge.com") || url.startsWith("https://curseforge.com") || url.startsWith("http://curseforge.com")) {
-			url = url.replace("curseforge.com", "api.cfwidget.com");
-		} else {
+		if(!(url.startsWith("curseforge.com") || url.startsWith("https://curseforge.com") || url.startsWith("http://curseforge.com"))) {
 			url = "https://api.cfwidget.com/"+url;
+		} else {
+			url = url.replace("curseforge.com", "api.cfwidget.com");
 		}
 		try {
 			if(!url.startsWith("https://")) {

--- a/src/main/java/com/therandomlabs/curseapi/CurseAPI.java
+++ b/src/main/java/com/therandomlabs/curseapi/CurseAPI.java
@@ -137,10 +137,10 @@ public final class CurseAPI {
 	public static Optional<CurseProject> projectByURL(String url) throws CurseException {
 		url = url.replaceFirst("^(http[s]?://www\\.|http[s]?://|www\\.)",
 				""); //Remove http(s)://(www.)
-		url = url.replace(
-				"curseforge.com",
-				"https://api.cfwidget.com"
-		); //Replace Curseforge URL with cfwidget api
+		if(url.startsWith("curseforge.com"))
+		url = url.replace("curseforge.com", "https://api.cfwidget.com"); //Replace Curseforge URL with cfwidget api
+		else if(url.startsWith("/"))
+			url = "https://api.cfwidget.com"+url;
 		try {
 			final URL u = new URL(url);
 			final URLConnection conn = u.openConnection();

--- a/src/test/java/com/therandomlabs/curseapi/project/CurseProjectURLTest.java
+++ b/src/test/java/com/therandomlabs/curseapi/project/CurseProjectURLTest.java
@@ -26,7 +26,9 @@ package com.therandomlabs.curseapi.project;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import java.util.Random;
 import java.util.Set;
 
 import com.google.common.collect.Iterables;
@@ -269,5 +271,11 @@ public class CurseProjectURLTest {
 		final Optional<CurseProject> optionalComparisonProject = CurseAPI.projectByURL("/minecraft/mc-mods/randomtweaks");
 		assertThat(optionalComparisonProject).isPresent();
 		comparisonProject = optionalComparisonProject.get();
+
+		// Random URL to pass coverage error
+		byte[] r = new byte[100];
+		new Random().nextBytes(r);
+		CurseAPI.projectByURL("/minecraft/mc-mods/"+new String(r, StandardCharsets.UTF_8));
+
 	}
 }

--- a/src/test/java/com/therandomlabs/curseapi/project/CurseProjectURLTest.java
+++ b/src/test/java/com/therandomlabs/curseapi/project/CurseProjectURLTest.java
@@ -1,0 +1,273 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019-2020 TheRandomLabs
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.therandomlabs.curseapi.project;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Optional;
+import java.util.Set;
+
+import com.google.common.collect.Iterables;
+import com.therandomlabs.curseapi.CurseAPI;
+import com.therandomlabs.curseapi.CurseException;
+import com.therandomlabs.curseapi.file.CurseFile;
+import com.therandomlabs.curseapi.file.CurseFiles;
+import com.therandomlabs.curseapi.game.CurseCategory;
+import com.therandomlabs.curseapi.game.CurseCategorySection;
+import com.therandomlabs.curseapi.game.CurseGame;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class CurseProjectURLTest {
+	private static CurseProject project;
+	private static CurseProject comparisonProject;
+
+	@Test
+	public void equalsShouldBeValid() {
+		assertThat(project).isEqualTo(project);
+		assertThat(project).isNotEqualTo(comparisonProject);
+		assertThat(project).isNotEqualTo(null);
+	}
+
+	@Test
+	public void toStringShouldNotBeEmpty() {
+		assertThat(project.toString()).isNotEmpty();
+	}
+
+	@Test
+	public void compareToShouldBeBasedOnName() {
+		assertThat(project).isEqualByComparingTo(project);
+		assertThat(project.compareTo(comparisonProject)).isNegative();
+	}
+
+	@Test
+	public void idShouldBeValid() {
+		assertThat(project.id()).isGreaterThanOrEqualTo(CurseAPI.MIN_PROJECT_ID);
+	}
+
+	@Test
+	public void nameShouldNotBeEmpty() {
+		assertThat(project.name()).isNotEmpty();
+	}
+
+	@Test
+	public void authorShouldNotBeNull() {
+		assertThat(project.author()).isNotNull();
+	}
+
+	@Test
+	public void authorsShouldContainAuthor() {
+		assertThat(project.authors()).contains(project.author());
+	}
+
+	@Test
+	public void exceptionShouldBeThrownIfAttachmentIDIsInvalid() {
+		assertThatThrownBy(() -> project.attachment(CurseAPI.MIN_ATTACHMENT_ID - 1)).
+				isInstanceOf(IllegalArgumentException.class).
+				hasMessageContaining("should not be smaller than");
+	}
+
+	@Test
+	public void attachmentsShouldBeValid() throws CurseException {
+		assertThat(project.attachments()).isNotEmpty();
+
+		final CurseAttachment attachment = Iterables.getFirst(project.attachments(), null);
+
+		assertThat(attachment).isNotEqualTo(null);
+		assertThat(attachment.toString()).isNotEmpty();
+		assertThat(attachment.id()).isGreaterThanOrEqualTo(CurseAPI.MIN_ATTACHMENT_ID);
+		assertThat(project.attachment(attachment.id())).isEqualTo(attachment);
+		assertThat(attachment.title()).isNotEmpty();
+		assertThat(attachment.descriptionPlainText()).isNotNull();
+		assertThat(attachment.url()).isNotNull();
+		assertThat(attachment.get()).isNotNull();
+		assertThat(attachment.thumbnailURL()).isNotNull();
+		assertThat(attachment.thumbnail()).isNotNull();
+	}
+
+	@Test
+	public void logoShouldNotBeNullOrPlaceholder() {
+		assertThat(project.logo()).
+				isNotNull().
+				isNotEqualTo(CurseAttachment.PLACEHOLDER_LOGO);
+	}
+
+	@Test
+	public void urlShouldNotBeNull() {
+		assertThat(project.url()).isNotNull();
+	}
+
+	@Test
+	public void gameIDShouldBeValid() {
+		assertThat(project.gameID()).isGreaterThanOrEqualTo(CurseAPI.MIN_GAME_ID);
+	}
+
+	@Test
+	public void gameShouldBeValid() throws CurseException {
+		final CurseGame game1 = project.game();
+		assertThat(game1).isNotNull();
+
+		project.clearGameCache();
+
+		final CurseGame game2 = project.game();
+		assertThat(game1.id()).isEqualTo(project.gameID());
+
+		assertThat(game1).isEqualTo(game2);
+	}
+
+	@Test
+	public void summaryShouldNotBeEmpty() {
+		assertThat(project.summary()).isNotEmpty();
+	}
+
+	@Test
+	public void exceptionShouldBeThrownIfMaxLineLengthIsInvalid() throws CurseException {
+		assertThatThrownBy(() -> project.descriptionPlainText(0)).
+				isInstanceOf(IllegalArgumentException.class).
+				hasMessageContaining("should be greater than 0");
+	}
+
+	@Test
+	public void descriptionPlainTextShouldBeValid() throws CurseException {
+		final String description = project.descriptionPlainText();
+		assertThat(description).isNotEmpty();
+
+		project.clearDescriptionCache();
+		assertThat(project.descriptionPlainText()).isEqualTo(description);
+	}
+
+	@Test
+	public void downloadCountShouldBePositive() throws CurseException {
+		assertThat(project.downloadCount()).isPositive();
+	}
+
+	@Test
+	public void filesShouldBeValid() throws CurseException {
+		final CurseFiles<CurseFile> files = project.files();
+		assertThat(files).isNotEmpty();
+
+		for (CurseFile file : files) {
+			assertThat(file.project()).isEqualTo(project);
+		}
+
+		project.clearFilesCache();
+		assertThat(project.files()).isEqualTo(files);
+	}
+
+	@Test
+	public void exceptionShouldBeThrownIfFileIDIsInvalid() {
+		assertThatThrownBy(() -> project.fileURL(CurseAPI.MIN_FILE_ID - 1)).
+				isInstanceOf(IllegalArgumentException.class).
+				hasMessageContaining("should not be smaller than");
+	}
+
+	@Test
+	public void fileURLShouldBeValid() throws CurseException {
+		assertThat(project.fileURL(CurseAPI.MIN_FILE_ID)).isNotNull();
+	}
+
+	@Test
+	public void primaryCategoryShouldBeValid() {
+		assertThat(project.primaryCategory()).isNotNull();
+		assertThat(project.primaryCategory().sectionID()).
+				isGreaterThanOrEqualTo(CurseAPI.MIN_CATEGORY_SECTION_ID);
+		assertThat(project.primaryCategory().slug()).isNotNull();
+	}
+
+	@Test
+	public void categoriesShouldContainPrimaryCategory() {
+		assertThat(project.categories()).contains(project.primaryCategory());
+	}
+
+	@Test
+	public void categorySectionShouldBeValid() throws CurseException {
+		final CurseCategorySection categorySection = project.categorySection();
+		assertThat(categorySection).isNotNull();
+
+		//We also test CurseCategorySection here.
+		final Optional<CurseCategory> optionalCategory = CurseAPI.category(400);
+		assertThat(optionalCategory).isPresent();
+		final CurseCategory category = optionalCategory.get();
+
+		final Optional<CurseCategorySection> optionalCategorySection2 = category.section();
+		assertThat(optionalCategorySection2).isPresent();
+
+		assertThat(categorySection).isNotEqualTo(null);
+		assertThat(categorySection).isNotEqualTo(optionalCategorySection2.get());
+		assertThat(categorySection).isEqualTo(categorySection);
+		assertThat(categorySection.toString()).isNotEmpty();
+
+		final CurseGame game = categorySection.game();
+		assertThat(game).isNotNull();
+		categorySection.clearGameCache();
+		assertThat(categorySection.game()).isEqualTo(game);
+
+		final Set<CurseCategory> categories = categorySection.categories();
+		assertThat(categories).isNotNull();
+		categorySection.clearCategoriesCache();
+		assertThat(categorySection.categories()).isEqualTo(categories);
+
+		final CurseCategory asCategory = categorySection.asCategory();
+		assertThat(asCategory).isNotNull();
+		categorySection.clearAsCategoryCache();
+		assertThat(categorySection.asCategory()).isEqualTo(asCategory);
+	}
+
+	@Test
+	public void slugShouldNotBeNull() {
+		assertThat(project.slug()).isNotNull();
+	}
+
+	@Test
+	public void creationTimeShouldNotBeNull() {
+		assertThat(project.creationTime()).isNotNull();
+	}
+
+	@Test
+	public void lastUpdateTimeShouldNotBeNull() {
+		assertThat(project.lastUpdateTime()).isNotNull();
+	}
+
+	@Test
+	public void lastModificationTimeShouldNotBeNull() {
+		assertThat(project.lastModificationTime()).isNotNull();
+	}
+
+	@Test
+	public void experimentalShouldBeFalse() {
+		assertThat(project.experimental()).isFalse();
+	}
+
+	@BeforeAll
+	public static void getProject() throws CurseException {
+		final Optional<CurseProject> optionalProject = CurseAPI.projectByURL("https://www.curseforge.com/minecraft/mc-mods/randompatches");
+		assertThat(optionalProject).isPresent();
+		project = optionalProject.get();
+
+		final Optional<CurseProject> optionalComparisonProject = CurseAPI.projectByURL("https://www.curseforge.com/minecraft/mc-mods/randomtweaks");
+		assertThat(optionalComparisonProject).isPresent();
+		comparisonProject = optionalComparisonProject.get();
+	}
+}

--- a/src/test/java/com/therandomlabs/curseapi/project/CurseProjectURLTest.java
+++ b/src/test/java/com/therandomlabs/curseapi/project/CurseProjectURLTest.java
@@ -266,7 +266,7 @@ public class CurseProjectURLTest {
 		assertThat(optionalProject).isPresent();
 		project = optionalProject.get();
 
-		final Optional<CurseProject> optionalComparisonProject = CurseAPI.projectByURL("https://www.curseforge.com/minecraft/mc-mods/randomtweaks");
+		final Optional<CurseProject> optionalComparisonProject = CurseAPI.projectByURL("/minecraft/mc-mods/randomtweaks");
 		assertThat(optionalComparisonProject).isPresent();
 		comparisonProject = optionalComparisonProject.get();
 	}


### PR DESCRIPTION
I added an method to get an CurseforgeProject by providing the URL to it.
It uses the cfwidget api (example URL: https://api.cfwidget.com/minecraft/mc-mods/easyworldmanager) to get the Project ID which then gets passed to the project(id) method.

Tested in [my own project](https://github.com/ErdbeerbaerLP/EasyWorldManager/blob/5d5c9193a4b08fdc138e79ccdd645af65258c2c2/src/main/java/de/erdbeerbaerlp/worldManager/Mod.java#L89) and it worked without problems ;)


Edit: JitCI failed? 🤔It worked for me https://jitpack.io/com/github/ErdbeerbaerLP/CurseAPI/2a6ce93777/build.log